### PR TITLE
Routes/URLs for quiz-results, dynamic URLs, CSS

### DIFF
--- a/frontend/src/components/StudySummaryCard.jsx
+++ b/frontend/src/components/StudySummaryCard.jsx
@@ -1,13 +1,19 @@
+import { useNavigate } from 'react-router-dom';
 import './styles/components.css';
 
-function StudySummaryCard({ study, onClick, selected }) {
+function StudySummaryCard({ study, selected }) {
+  const navigate = useNavigate();
   const participantCount = study.participants?.length || 0;
   const cardClasses = `summary-card${selected ? ' summary-card--expanded' : ''}`;
 
+  const handleClick = () => {
+    navigate(`/results/${study.id}`);
+  };
+
   return (
-    <div className={cardClasses} onClick={() => onClick(study)}>
+    <div className={cardClasses} onClick={handleClick}>
       <h2>{study.name}</h2>
-      <div className='details-area'>
+      <div className="details-area">
         <p>Study ID: <span>{study.id}</span></p>
         <p>{participantCount} participant{participantCount !== 1 ? 's' : ''}</p>
         <p>Click to view results for this study.</p>

--- a/frontend/src/pages/styles/ResultsPage.css
+++ b/frontend/src/pages/styles/ResultsPage.css
@@ -1,7 +1,11 @@
 /* ### CSS for the Results-page and its StudySummaryCard-component. ### */
+* {
+    box-sizing: border-box;
+  }  
 
 /* The page title (header) */
 h1 {
+    color: #777;
     margin: 10px auto;
 }
 
@@ -121,11 +125,15 @@ th, td {
 
 /* Helper-text for information on how to return/go back from a specific study. */
 .return-text {
-    font-style: italic;
-    font-size: 1.2em;
     background-color: #777;
     color: white;
+    font-style: italic;
+    font-size: 1.2em;
+    margin: 0 auto;
     margin-top: 1rem;
+    border-radius: 10px;
     cursor: pointer;
     display: inline-block;
+    padding: 10px;
+    text-align: center;
 }

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -69,13 +69,21 @@ const AppRoutes = () => {
           <Dashboard />
         </ProtectedRoute>
       } />
+
       <Route path="/create-study" element={
         //made public for the presentation
         <PublicRoute>
           <CreateStudy/>
         </PublicRoute>
       } />
+
       <Route path="/results" element={
+        <ProtectedRoute>
+          <ResultsPage />
+        </ProtectedRoute>
+      } />
+      
+      <Route path="/results/:id" element={
         <ProtectedRoute>
           <ResultsPage />
         </ProtectedRoute>


### PR DESCRIPTION
* Added URLs when clicking on the results of a quiz in the results page.
* Used "useParams" and "useNavigate" to ensure dynamic URLs when navigating into a quiz, implemented this in "ResultsPage" and "StudySummaryCard".
* Added new dynamic routes into "AppRoutes" as a new protected route.
* Moved the helper text for returning from a quiz out of the right card in the detailed view. Now it's cleanly underneat the detailed card view.
* Improved and cleaned up layout (and CSS-code) for the summary card displays.
* Added new comments.
* Maybe some other stuff.